### PR TITLE
Fixed off-by-one error

### DIFF
--- a/s7plc.html
+++ b/s7plc.html
@@ -840,12 +840,13 @@ valid for longout records.
 </pre>
 <p>
 Default and only valid type is <code>T=STRING</code>.
-Default length is <code>L=40</code>.
+Default (and maximum) length is <code>L=40</code>.
 </p>
 <p>
 <code>L</code> bytes are read from the PV to <code>VAL</code> and null
-terminated. Thus, the effective string length is maximal
-<code>L</code>-1 bytes.
+terminated. Because the stringin record uses a fixed size, 40-byte long
+buffer if <code>L&lt;40</code>, the effective string length is <code>L</code>
+bytes.  If <code>L=40</code>, the effective string length is 39 bytes.
 </p>
 
 <a name="stringout"></a>


### PR DESCRIPTION
With L==40, the terminating null byte was written after the end of VAL right into OVAL (continuously triggering a monitor). The proposed fix is more general than a simple "- 1":

Always zero out the whole 40 byte buffer of stringin and transmit only
39 bytes if requested length is 40. This way we make sure that the
resulting string is always null terminated even if the PLC sends a
non-terminated one. It also means that the effective maximum string
length is 39.