### PR TITLE
Remove base.dbd from s7plc.dbd

### DIFF
--- a/S7plcApp/src/Makefile
+++ b/S7plcApp/src/Makefile
@@ -16,9 +16,8 @@ endif
 HTMLS_DIR = $(TOP)/html
 HTMLS += s7plc.html
 
-# Install xxxSupport.dbd into <top>/dbd
-DBD += s7plc.dbd
-s7plc_DBD += base.dbd
+DBDCAT += s7plc.dbd
+
 s7plc_DBD += s7plcBase.dbd
 s7plc_DBD += s7plcCalcout.dbd
 s7plc_DBD += s7plcReg.dbd
@@ -42,19 +41,17 @@ s7plc_LIBS += $(EPICS_BASE_IOC_LIBS)
 PROD_IOC = S7plcApp
 
 # S7plcApp.dbd will be created and installed
-#DBD += S7plcApp.dbd
-#
+DBD += S7plcApp.dbd
+
+S7plcApp.dbd$(DEP): $(COMMON_DIR)/s7plc.dbd
+
+
 ## S7plcApp.dbd will include these files:
-#S7plcApp_DBD += base.dbd
-#S7plcApp_DBD += s7plcBase.dbd
-#S7plcApp_DBD += s7plcCalcout.dbd
-#S7plcApp_DBD += s7plcReg.dbd
-#ifdef EPICS_INT64
-#	S7plcApp_DBD += s7plcInt64.dbd
-#endif
+S7plcApp_DBD += base.dbd
+S7plcApp_DBD += s7plc.dbd
 
 # S7plcApp_registerRecordDeviceDriver.cpp derives from S7plcApp.dbd
-S7plcApp_SRCS += s7plc_registerRecordDeviceDriver.cpp
+S7plcApp_SRCS += S7plcApp_registerRecordDeviceDriver.cpp
 
 # Build the main IOC entry point where needed
 S7plcApp_SRCS_DEFAULT += S7plcMain.cpp

--- a/iocBoot/iocS7plc/st.cmd
+++ b/iocBoot/iocS7plc/st.cmd
@@ -5,8 +5,8 @@
 cd "${TOP}"
 
 ## Register all support components
-dbLoadDatabase "dbd/s7plc.dbd"
-s7plc_registerRecordDeviceDriver pdbbase
+dbLoadDatabase "dbd/S7plcApp.dbd"
+S7plcApp_registerRecordDeviceDriver pdbbase
 
 #var s7plcDebug <level>
 #level=-1:  no output


### PR DESCRIPTION
The support library and test IOC were not properly separated: base.dbd was included in the support library's dbd instead of the test app's dbd, and registration code for the test app was generated from the support module's dbd. Consequently, any application that used the s7plc module had to include s7plc.dbd *first*, and *not* include base.dbd itself. This is contrary to the usual practice, and can be confusing because it's not obvious why the ordering of s7plc relative to unrelated support modules should matter.
