### PR TITLE
Remove HTMLS_DIR variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib
 dbd
 db
 *envPaths
+html

--- a/S7plcApp/src/Makefile
+++ b/S7plcApp/src/Makefile
@@ -13,7 +13,6 @@ EPICS_INT64 = true
 endif
 
 # Documentation
-HTMLS_DIR = $(TOP)/html
 HTMLS += s7plc.html
 
 # Install xxxSupport.dbd into <top>/dbd


### PR DESCRIPTION
With previous configuration the make process set the variable `$(TOP)` to `../../..` and the final install location was `$(APP_TOP)/html/../../../html/s7plc.html`

Now the `s7plc.html` is installed to `$(APP_TOP)/html/`

Added `$(APP_TOP)/html` location to `.gitignore`